### PR TITLE
Feat: timeout and retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Default request timeout of 120 seconds for all HTTP requests (aligned with weclapp recommendation of at least one minute). Callers can override by passing `timeout` in request kwargs.
 - Documentation on how to build
 - Remove generated changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Default request timeout of 120 seconds for all HTTP requests (aligned with weclapp recommendation of at least one minute). Callers can override by passing `timeout` in request kwargs.
+- Extend existing Retry logic to also handle 429 responses.
 - Documentation on how to build
 - Remove generated changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- HTTP request timing logging: every API call logs method, endpoint path, status code, and duration in milliseconds
+- Slow request detection: calls taking >= 2000ms log at WARNING level with `[API_SLOW]` prefix; all others log at INFO with `[API]` prefix
+- Configurable slow threshold via `slow_threshold_ms` parameter in `Weclapp.__init__()` (default: 2000ms)
+- Timing instrumentation covers both `_send_request()` and the direct count endpoint call in threaded `get_all`
+- Query parameters are stripped from logged paths for security (tokens, filters never appear in logs)
 - Default request timeout of 120 seconds for all HTTP requests (aligned with weclapp recommendation of at least one minute). Callers can override by passing `timeout` in request kwargs.
 - Documentation on how to build
 - Remove generated changelog

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # Feature requests
 
-- Exponential retries on 429 error
 - Threaded writing
 - Generators

--- a/tests/test_weclappy_unit.py
+++ b/tests/test_weclappy_unit.py
@@ -36,7 +36,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "GET",
             "https://test.weclapp.com/webapp/api/v1/article/id/123",
-            params={}
+            params={},
+            timeout=120,
         )
 
         # Verify the result
@@ -64,7 +65,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "GET",
             "https://test.weclapp.com/webapp/api/v1/article",
-            params={}
+            params={},
+            timeout=120,
         )
 
         # Verify the result
@@ -105,7 +107,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "GET",
             "https://test.weclapp.com/webapp/api/v1/article",
-            params={"additionalProperties": "currentSalesPrice"}
+            params={"additionalProperties": "currentSalesPrice"},
+            timeout=120,
         )
 
         # Verify the result
@@ -141,7 +144,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "GET",
             "https://test.weclapp.com/webapp/api/v1/article",
-            params={"additionalProperties": "currentSalesPrice,averagePrice"}
+            params={"additionalProperties": "currentSalesPrice,averagePrice"},
+            timeout=120,
         )
 
         # Verify the result
@@ -180,7 +184,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "GET",
             "https://test.weclapp.com/webapp/api/v1/article",
-            params={"includeReferencedEntities": "unitId"}
+            params={"includeReferencedEntities": "unitId"},
+            timeout=120,
         )
 
         # Verify the result
@@ -218,7 +223,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "GET",
             "https://test.weclapp.com/webapp/api/v1/article",
-            params={"includeReferencedEntities": "unitId,articleCategoryId"}
+            params={"includeReferencedEntities": "unitId,articleCategoryId"},
+            timeout=120,
         )
 
         # Verify the result
@@ -262,8 +268,9 @@ class TestWeclappUnit(unittest.TestCase):
             "https://test.weclapp.com/webapp/api/v1/article",
             params={
                 "additionalProperties": "currentSalesPrice",
-                "includeReferencedEntities": "unitId"
-            }
+                "includeReferencedEntities": "unitId",
+            },
+            timeout=120,
         )
 
         # Verify the result
@@ -398,7 +405,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "POST",
             "https://test.weclapp.com/webapp/api/v1/article",
-            json=data
+            json=data,
+            timeout=120,
         )
 
         # Verify the result
@@ -424,7 +432,8 @@ class TestWeclappUnit(unittest.TestCase):
             "PUT",
             "https://test.weclapp.com/webapp/api/v1/article/id/123",
             json=data,
-            params={"ignoreMissingProperties": True}
+            params={"ignoreMissingProperties": True},
+            timeout=120,
         )
 
         # Verify the result
@@ -447,7 +456,8 @@ class TestWeclappUnit(unittest.TestCase):
         mock_request.assert_called_once_with(
             "DELETE",
             "https://test.weclapp.com/webapp/api/v1/article/id/123",
-            params={}
+            params={},
+            timeout=120,
         )
 
         # Verify the result (empty dict for 204 response)
@@ -476,7 +486,8 @@ class TestWeclappUnit(unittest.TestCase):
             "GET",
             "https://test.weclapp.com/webapp/api/v1/salesInvoice/id/123/downloadLatestSalesInvoicePdf",
             json=None,
-            params=None
+            params=None,
+            timeout=120,
         )
 
         # Verify the result

--- a/tests/test_weclappy_unit.py
+++ b/tests/test_weclappy_unit.py
@@ -1237,5 +1237,150 @@ class TestDownloadMethod(unittest.TestCase):
         self.assertEqual(call_args[0][1], "https://test.weclapp.com/webapp/api/v1/someEndpoint/someAction")
 
 
+class TestRequestTimingLogging(unittest.TestCase):
+    """Tests for HTTP request timing logging."""
+
+    def setUp(self):
+        self.base_url = "https://test.weclapp.com/webapp/api/v1"
+        self.api_key = "test_api_key"
+        self.weclapp = Weclapp(self.base_url, self.api_key)
+
+    @patch('weclappy.time.monotonic')
+    @patch('weclappy.logger')
+    @patch('weclappy.requests.Session.request')
+    def test_normal_request_logs_info_with_api_prefix(self, mock_request, mock_logger, mock_monotonic):
+        """Normal request logs at INFO with [API] prefix and correct format."""
+        mock_monotonic.side_effect = [0.0, 0.342]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"id": "123", "name": "Test"}
+        mock_request.return_value = mock_response
+
+        self.weclapp.get("salesOrder", id="123")
+
+        mock_logger.info.assert_any_call(
+            "[API] Weclapp GET /webapp/api/v1/salesOrder/id/123 -> 200 (342ms)"
+        )
+
+    @patch('weclappy.time.monotonic')
+    @patch('weclappy.logger')
+    @patch('weclappy.requests.Session.request')
+    def test_slow_request_logs_warning_with_api_slow_prefix(self, mock_request, mock_logger, mock_monotonic):
+        """Slow request (>= threshold) logs at WARNING with [API_SLOW] prefix."""
+        mock_monotonic.side_effect = [0.0, 3.421]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"result": []}
+        mock_request.return_value = mock_response
+
+        self.weclapp.get("shipment")
+
+        mock_logger.warning.assert_any_call(
+            "[API_SLOW] Weclapp GET /webapp/api/v1/shipment -> 200 (3421ms)"
+        )
+
+    @patch('weclappy.time.monotonic')
+    @patch('weclappy.logger')
+    @patch('weclappy.requests.Session.request')
+    def test_error_request_logs_warning_with_error_status(self, mock_request, mock_logger, mock_monotonic):
+        """Error request logs at WARNING with ERROR status and exception info."""
+        mock_monotonic.side_effect = [0.0, 5.123]
+        mock_request.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        with self.assertRaises(WeclappAPIError):
+            self.weclapp.put("salesOrder", id="12345", data={"name": "Test"})
+
+        mock_logger.warning.assert_any_call(
+            "[API] Weclapp PUT /webapp/api/v1/salesOrder/id/12345 -> ERROR (5123ms) "
+            "ConnectionError: Connection refused"
+        )
+
+    @patch('weclappy.time.monotonic')
+    @patch('weclappy.logger')
+    @patch('weclappy.requests.Session.request')
+    def test_count_endpoint_in_threaded_get_all_is_logged(self, mock_request, mock_logger, mock_monotonic):
+        """The count endpoint in threaded get_all is also timed and logged."""
+        mock_monotonic.side_effect = [0.0, 0.156, 0.2, 0.5]
+
+        count_response = MagicMock()
+        count_response.status_code = 200
+        count_response.json.return_value = {"result": 1}
+
+        page_response = MagicMock()
+        page_response.status_code = 200
+        page_response.headers = {"Content-Type": "application/json"}
+        page_response.json.return_value = {"result": [{"id": "1"}]}
+
+        mock_request.side_effect = [count_response, page_response]
+
+        self.weclapp.get_all("salesOrder", threaded=True)
+
+        mock_logger.info.assert_any_call(
+            "[API] Weclapp GET /webapp/api/v1/salesOrder/count -> 200 (156ms)"
+        )
+
+    def test_default_slow_threshold_ms(self):
+        """Default slow_threshold_ms is 2000."""
+        self.assertEqual(self.weclapp.slow_threshold_ms, 2000)
+
+    def test_custom_slow_threshold_ms_in_constructor(self):
+        """Custom slow_threshold_ms in constructor is respected."""
+        weclapp = Weclapp(self.base_url, self.api_key, slow_threshold_ms=500)
+        self.assertEqual(weclapp.slow_threshold_ms, 500)
+
+    @patch('weclappy.time.monotonic')
+    @patch('weclappy.logger')
+    @patch('weclappy.requests.Session.request')
+    def test_custom_slow_threshold_triggers_warning(self, mock_request, mock_logger, mock_monotonic):
+        """Custom slow threshold triggers WARNING at the configured value."""
+        weclapp = Weclapp(self.base_url, self.api_key, slow_threshold_ms=500)
+        mock_monotonic.side_effect = [0.0, 0.6]  # 600ms > 500ms threshold
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"id": "123"}
+        mock_request.return_value = mock_response
+
+        weclapp.get("article", id="123")
+
+        mock_logger.warning.assert_any_call(
+            "[API_SLOW] Weclapp GET /webapp/api/v1/article/id/123 -> 200 (600ms)"
+        )
+
+    @patch('weclappy.time.monotonic')
+    @patch('weclappy.logger')
+    @patch('weclappy.requests.Session.request')
+    def test_query_params_not_in_logged_path(self, mock_request, mock_logger, mock_monotonic):
+        """Query params are never included in logged path."""
+        mock_monotonic.side_effect = [0.0, 0.1]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"result": []}
+        mock_request.return_value = mock_response
+
+        self.weclapp.get("salesOrder", params={"token": "secret123", "filter": "active"})
+
+        # Verify the exact log message contains only the path, no query params
+        mock_logger.info.assert_any_call(
+            "[API] Weclapp GET /webapp/api/v1/salesOrder -> 200 (100ms)"
+        )
+
+        # Verify no timing log call contains sensitive query params
+        all_calls = mock_logger.info.call_args_list + mock_logger.warning.call_args_list
+        for call_args in all_calls:
+            if call_args[0]:
+                msg = str(call_args[0][0])
+                if "[API]" in msg or "[API_SLOW]" in msg:
+                    self.assertNotIn("secret123", msg)
+                    self.assertNotIn("token=", msg)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/weclappy.py
+++ b/weclappy.py
@@ -72,6 +72,7 @@ def infer_content_type(filename: Optional[str]) -> Optional[str]:
 DEFAULT_PAGE_SIZE = 1000
 DEFAULT_MAX_WORKERS = 10
 DEFAULT_REQUEST_TIMEOUT = 120  # seconds; weclapp may queue requests up to ~30s before 429
+DEFAULT_BACKOFF_FACTOR = 0.3  # exponential backoff between retries (seconds)
 
 class WeclappAPIError(Exception):
     """Custom exception for Weclapp API errors.
@@ -298,12 +299,12 @@ class Weclapp:
             "AuthenticationToken": api_key
         })
 
-        # Configure HTTP retry strategy
+        # Configure HTTP retry strategy (5xx and 429 with exponential backoff)
         retry_strategy = Retry(
             total=3,
-            backoff_factor=0.3,
-            status_forcelist=[500, 502, 503, 504],
-            allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"]
+            backoff_factor=DEFAULT_BACKOFF_FACTOR,
+            status_forcelist=[500, 502, 503, 504, 429],
+            allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"],
         )
 
         # Create an adapter with bigger pool size

--- a/weclappy.py
+++ b/weclappy.py
@@ -71,6 +71,7 @@ def infer_content_type(filename: Optional[str]) -> Optional[str]:
 
 DEFAULT_PAGE_SIZE = 1000
 DEFAULT_MAX_WORKERS = 10
+DEFAULT_REQUEST_TIMEOUT = 120  # seconds; weclapp may queue requests up to ~30s before 429
 
 class WeclappAPIError(Exception):
     """Custom exception for Weclapp API errors.
@@ -353,6 +354,7 @@ class Weclapp:
         :return: Dict or binary dict structure (for files).
         :raises WeclappAPIError: if the request fails or returns non-2xx status.
         """
+        kwargs.setdefault("timeout", DEFAULT_REQUEST_TIMEOUT)
         try:
             response = self.session.request(method, url, **kwargs)
             self._check_response(response)
@@ -545,7 +547,9 @@ class Weclapp:
             # Special handling for count endpoint which returns an integer directly
             url = urljoin(self.base_url, count_endpoint)
             logger.debug(f"GET {url} with params {params}")
-            response = self.session.request("GET", url, params=params)
+            response = self.session.request(
+                "GET", url, params=params, timeout=DEFAULT_REQUEST_TIMEOUT
+            )
             self._check_response(response)
             total_count = response.json().get('result', 0) if response.status_code == 200 else 0
 

--- a/weclappy.py
+++ b/weclappy.py
@@ -2,9 +2,10 @@ import json
 import math
 import logging
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from dataclasses import dataclass
 
 import requests
@@ -72,6 +73,7 @@ def infer_content_type(filename: Optional[str]) -> Optional[str]:
 DEFAULT_PAGE_SIZE = 1000
 DEFAULT_MAX_WORKERS = 10
 DEFAULT_REQUEST_TIMEOUT = 120  # seconds; weclapp may queue requests up to ~30s before 429
+SLOW_REQUEST_THRESHOLD_MS = 2000
 
 class WeclappAPIError(Exception):
     """Custom exception for Weclapp API errors.
@@ -281,7 +283,8 @@ class Weclapp:
         base_url: str,
         api_key: str,
         pool_connections: int = 100,
-        pool_maxsize: int = 100
+        pool_maxsize: int = 100,
+        slow_threshold_ms: int = SLOW_REQUEST_THRESHOLD_MS
     ) -> None:
         """
         Initialize the Weclapp client.
@@ -292,6 +295,7 @@ class Weclapp:
         :param pool_maxsize: Maximum number of connections per pool (default=100).
         """
         self.base_url = base_url.rstrip('/') + '/'
+        self.slow_threshold_ms = slow_threshold_ms
         self.session = requests.Session()
         self.session.headers.update({
             "Content-Type": "application/json",
@@ -355,8 +359,13 @@ class Weclapp:
         :raises WeclappAPIError: if the request fails or returns non-2xx status.
         """
         kwargs.setdefault("timeout", DEFAULT_REQUEST_TIMEOUT)
+        path = urlparse(url).path
+        start = time.monotonic()
+        status_code = None
+        error = None
         try:
             response = self.session.request(method, url, **kwargs)
+            status_code = response.status_code
             self._check_response(response)
 
             # If no content or 204 No Content, return an empty dict
@@ -395,6 +404,7 @@ class Weclapp:
                 return {"content": response.text, "content_type": content_type}
 
         except requests.exceptions.RequestException as e:
+            error = e
             logger.error(f"HTTP {method} request failed for {url}: {e}")
             # Use response.text if available for error details
             response_text = None
@@ -411,6 +421,22 @@ class Weclapp:
             raise WeclappAPIError(
                 error_message, response=response_obj, response_text=response_text
             ) from e
+        finally:
+            duration_ms = (time.monotonic() - start) * 1000
+            if error is not None:
+                logger.warning(
+                    f"[API] Weclapp {method} {path} -> ERROR ({duration_ms:.0f}ms) "
+                    f"{type(error).__name__}: {error}"
+                )
+            elif status_code is not None:
+                if duration_ms >= self.slow_threshold_ms:
+                    logger.warning(
+                        f"[API_SLOW] Weclapp {method} {path} -> {status_code} ({duration_ms:.0f}ms)"
+                    )
+                else:
+                    logger.info(
+                        f"[API] Weclapp {method} {path} -> {status_code} ({duration_ms:.0f}ms)"
+                    )
 
     def get(
         self,
@@ -547,11 +573,36 @@ class Weclapp:
             # Special handling for count endpoint which returns an integer directly
             url = urljoin(self.base_url, count_endpoint)
             logger.debug(f"GET {url} with params {params}")
-            response = self.session.request(
-                "GET", url, params=params, timeout=DEFAULT_REQUEST_TIMEOUT
-            )
-            self._check_response(response)
-            total_count = response.json().get('result', 0) if response.status_code == 200 else 0
+            count_path = urlparse(url).path
+            count_start = time.monotonic()
+            count_status = None
+            count_error = None
+            try:
+                response = self.session.request(
+                    "GET", url, params=params, timeout=DEFAULT_REQUEST_TIMEOUT
+                )
+                count_status = response.status_code
+                self._check_response(response)
+                total_count = response.json().get('result', 0) if response.status_code == 200 else 0
+            except requests.exceptions.RequestException as e:
+                count_error = e
+                raise
+            finally:
+                count_duration_ms = (time.monotonic() - count_start) * 1000
+                if count_error is not None:
+                    logger.warning(
+                        f"[API] Weclapp GET {count_path} -> ERROR ({count_duration_ms:.0f}ms) "
+                        f"{type(count_error).__name__}: {count_error}"
+                    )
+                elif count_status is not None:
+                    if count_duration_ms >= self.slow_threshold_ms:
+                        logger.warning(
+                            f"[API_SLOW] Weclapp GET {count_path} -> {count_status} ({count_duration_ms:.0f}ms)"
+                        )
+                    else:
+                        logger.info(
+                            f"[API] Weclapp GET {count_path} -> {count_status} ({count_duration_ms:.0f}ms)"
+                        )
 
             if total_count == 0:
                 logger.info(f"No records found for entity '{entity}'")


### PR DESCRIPTION
Default request timeout (120s): All HTTP requests now have a 120-second timeout by default (via DEFAULT_REQUEST_TIMEOUT), aligned with weclapp's recommendation of at least one minute. This covers both _send_request() and the direct count endpoint call in threaded get_all. Callers can still override per-request.

429 retry with exponential backoff: Added HTTP 429 (Too Many Requests) to the existing urllib3 Retry status_forcelist alongside 5xx errors. Uses the new DEFAULT_BACKOFF_FACTOR (0.3s) constant for exponential backoff. Retry-After headers are respected by default.

Request timing logging: Every API call now logs method, endpoint path, status code, and duration in milliseconds. Requests taking >= 2000ms log at WARNING level with [API_SLOW] prefix; others log at INFO with [API] prefix. The slow threshold is configurable via slow_threshold_ms in the constructor. Query parameters are stripped from logged paths for security.